### PR TITLE
Remove CallNumber normalization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ For the call number `741.4372 A123b c.2 v.3 2004`:
 `additional` | `c.2 v.3 2004`
 `call number`| `741.4372`
 
-What's also a bit confusing is the differentiation between a call number and a CallNumber object. Unless specifically referencing the CallNumber object's $callNumber field, the camel-cased CallNumber refers to the object and lowere cased `call number` refers to the major/minor combination.
+What's also a bit confusing is the differentiation between a call number and a CallNumber object. Unless specifically referencing the CallNumber object's $callNumber field, the camel-cased CallNumber refers to the object and lower-cased `call number` refers to the major/minor combination.
 
 Please add an issue if you've got some suggestions re: clearing the code up!
 
@@ -76,7 +76,7 @@ var_dump(Dewey::parseCallNumber("741.4372 A123x"));
 
 ### `Dewey\CallNumber` ###
 
-A `CallNumber` object is a representation of a DDS call number. To compare one against another, a "normalized" numeric representation is calculated. The decimal + and spaces are removed, alphabetical characters are converted to a two-digit representation, and these numbers are padded with zeros to match the longer of the two being compared. The call number, cutter, and (eventually) additional information are calculated seperately and joined together.
+A `CallNumber` object is a representation of a DDS call number.
 
 An object can be constructed by using `Dewey::parseCallNumber` or by instantiating a `new Dewey\CallNumber` with a DDS call number string as a parameter (which uses the former under the hood anyway).
 

--- a/src/Dewey.php
+++ b/src/Dewey.php
@@ -87,29 +87,53 @@ class Dewey {
             $comp = self::parseCallNumber($comp);
         }
 
+        /**
+         *  compare the float vals of each call numbers _first_
+         *  then, if need be, move on to the normalized cutters
+         */
+
+        $inputCNfloat = floatval($input->getCallNumber());
+        $compCNfloat = floatval($comp->getCallNumber());
+
+        if ( $inputCNfloat !== $compCNfloat ) {
+            switch($operator) {
+                case ">" :
+                case ">=": return $inputCNfloat > $compCNfloat;
+
+                case "<" :
+                case "<=": return $inputCNfloat < $compCNfloat;
+
+                case "==" :
+                case "===": return false;
+
+                default: throw new \InvalidArgumentException("Invalid operator: [{$operator}]");
+            }
+        }
+
+        /**
+         *  If our call number is equal, we need to compare cutters.
+         *  We'll pad the shorter cutter with 0s.
+         *
+         *
+         */
+
         // check for longest field to pad
-        $inputCNLength = $input->getNormalizedCallNumberLength();
-        $compCNLength = $comp->getNormalizedCallNumberLength();
-        $inputCTLength = $input->getNormalizedCutterLength();
-        $compCTLength = $comp->getNormalizedCutterLength();
+        $inputCTLength = $input->getCutterLength();
+        $compCTLength = $comp->getCutterLength();
+        $padding = $inputCTLength > $compCTLength ? $inputCTLength : $compCTLength;
 
-        $padding = array(
-            'callNumber' => $inputCNLength > $compCNLength ? $inputCNLength : $compCNLength,
-            'cutter'     => $inputCTLength > $compCTLength ? $inputCTLength : $compCTLength
-        );
-
-        $inputNormalized = $input->calculateNormalized($padding);
-        $compNormalized = $comp->calculateNormalized($padding);
+        $inputCT = str_pad($input->getCutter(), $padding, "0", STR_PAD_RIGHT);
+        $compCT = str_pad($comp->getCutter(), $padding, "0", STR_PAD_RIGHT);
 
         switch($operator) {
-            case ">":  return $inputNormalized >  $compNormalized;
-            case "<":  return $inputNormalized <  $compNormalized;
-            case "<=": return $inputNormalized <= $compNormalized;
-            case ">=": return $inputNormalized >= $compNormalized;
-            case "==": return $inputNormalized == $compNormalized;
+            case ">":  return strtolower($inputCT) >  strtolower($compCT);
+            case "<":  return strtolower($inputCT) <  strtolower($compCT);
+            case "<=": return strtolower($inputCT) <= strtolower($compCT);
+            case ">=": return strtolower($inputCT) >= strtolower($compCT);
+            case "==": return strtolower($inputCT) == strtolower($compCT);
 
             // unneccessary but available
-            case "===": return $inputNormalized === $compNormalized;
+            case "===": return strtolower($inputCT) === strtolower($compCT);
             default: throw new \InvalidArgumentException("Invalid operator: [{$operator}]");
         }
     }

--- a/test/CallNumberTest.php
+++ b/test/CallNumberTest.php
@@ -6,12 +6,6 @@ class CallNumberTest extends PHPUnit_Framework_TestCase {
     protected $callNumber = "514.123";
     protected $cutter = "A987x";
 
-    protected $normalized           = "5141230198724";
-    protected $normalizedLessDigits = "5141000198724";
-    protected $normalizedCNPadded   = "514123000198724";
-    protected $normalizedCTPadded   = "51412301987240";
-    protected $normalizedPadded     = "5141230001987240";
-
     public function setUp() {
         $this->cn = new Dewey\CallNumber;
         $this->cn->setCallNumber($this->callNumber);
@@ -23,28 +17,6 @@ class CallNumberTest extends PHPUnit_Framework_TestCase {
             $this->callNumberString, 
             $this->cn . '',
             'CallNumber prints as a readable DDS call number'
-        );
-    }
-
-    public function testCalculateNormalizedCutter() {
-        $ct = "0198724";
-        
-        $this->assertEquals(
-            $ct, 
-            $this->cn->calculateNormalizedCutter(),
-            'no padding'
-        );
-        
-        $this->assertEquals(
-            $ct, 
-            $this->cn->calculateNormalizedCutter($this->cn->getNormalizedCutterLength() - 1),
-            'slight pading'
-        );
-
-        $this->assertEquals(
-            $ct . "00", 
-            $this->cn->calculateNormalizedCutter($this->cn->getNormalizedCutterLength() + 2), 
-            'noticeable padding'
         );
     }
 
@@ -66,14 +38,7 @@ class CallNumberTest extends PHPUnit_Framework_TestCase {
     public function testGetCutterLength() {
         $this->assertEquals(
             5, 
-            $this->cn->getCutterLength(),
-            'Getting the cutter length should return not normalized length'
-        );
-
-        $this->assertEquals(
-            7,
-            $this->cn->getCutterLength(true),
-            'Passing `true` to getCutterLength will calculate normalized cutter length'
+            $this->cn->getCutterLength()
         );
     }
 
@@ -144,37 +109,6 @@ class CallNumberTest extends PHPUnit_Framework_TestCase {
         $this->assertTrue(
             $this->cn->lessThanEqualTo($this->cn),
             'lessThanEqualTo self should return true'
-        );
-    }
-
-    public function testNormalized() {
-        $this->assertEquals($this->normalized, $this->cn->calculateNormalized());
-    }
-
-    public function testNormalizedCallNumberPadding() {
-        $this->assertEquals(
-            $this->normalizedCNPadded,
-            $this->cn->calculateNormalized(array('callNumber' => 8))
-        );
-
-        $this->cn->setCallNumber("514.1");
-        $this->assertEquals(
-            $this->normalizedLessDigits,
-            $this->cn->calculateNormalized(array('callNumber' => 6))
-        );
-    }
-
-    public function testNormalizedCutterPadding() {        
-        $this->assertEquals(
-            $this->normalizedCTPadded,
-            $this->cn->calculateNormalized(array('cutter' => 8))
-        );
-    }
-
-    public function testNormalizedPadding() {
-        $this->assertEquals(
-            $this->normalizedPadded,
-            $this->cn->calculateNormalized(array('callNumber' => 8, 'cutter' => 8))
         );
     }
 }


### PR DESCRIPTION
The comparison process is now _much_ simpler. The two call numbers are parsed as floats and compared.
If equal, then their cutters are compared. This led to a pretty huge increase in speed:

the test:

    require "vendor/autoload.php";

    for( $i = 0; $i < 1000000; $i++ ) {
        Dewey::compare("741.1234 A123c", "741.1234 A12", ">=");
    }

and the results:

w/ normalization:

    > time php test.php

    real    0m52.567s
    user    0m45.933s
    sys     0m0.329s

w/o normalization:

    > time php test.php

    real    0m18.844s
    user    0m17.792s
    sys     0m0.081s

So that's pretty rad! _And_ none of the tests broke!