### PR TITLE
`x` range delimiter now `*`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,22 +28,22 @@ The `Dewey` class has a few static methods for general use:
 
 ### `Dewey::calculateRange($rangeString)` ###
 
-Calculate the range of DDS call numbers using an `x` to specify where the range takes place.
+Calculate the range of DDS call numbers using an `*` to specify where the range takes place.
 Returns a tuple array of `[$min, $max]`
 
 #### example ####
 
 ```php
-$drawing = Dewey::calculateRange("74x");
+$drawing = Dewey::calculateRange("74*");
 // returns `array("740", "750")`
 ```
 
 range string | returned array
 -------------|---------------
-`7xx`        | `["700", "800"]`
-`74x`        | `["740", "750"]`
-`741.x`      | `["741", "742"]`
-`741.4x`     | `["741.4", "741.5"]`
+`7**`        | `["700", "800"]`
+`74*`        | `["740", "750"]`
+`741.*`      | `["741", "742"]`
+`741.4*`     | `["741.4", "741.5"]`
 
 ### `Dewey::compare($input, $comparison, $operator)` ###
 

--- a/src/Dewey.php
+++ b/src/Dewey.php
@@ -5,18 +5,16 @@ class Dewey {
     const DDS_FULL_REGEX = "/(\d{1,3})\.?([^\s]*)?\s*([^\s]*)?\s*(.*)?/";
 
     /**
-     *  calculates range based on x-substituted strings, return as a tuple array
+     *  calculates range based on *-substituted strings, return as a tuple array
      *
-     *      ex. "74x" will return ["740", "750"]
-     *      ex. "7xx" will return ["700", "800"]
+     *      ex. "74*" will return ["740", "750"]
+     *      ex. "7**" will return ["700", "800"]
      *
      *  when using a DDS minor will calculate w/ the decimal, but probably not necessary
      * 
-     *      ex. "74x.22" will return ["740.22", "750.22"]
+     *      ex. "74*.22" will return ["740.22", "750.22"]
      *
-     *  and will _not_ work w/ cutters, as our placeholder (`x`) may be used w/in a cutter
-     *
-     *  @param  string  call number to range, using X to denote where the range is (see above)
+     *  @param  string  call number to range, using * to denote where the range is (see above)
      *  @return array   tuple array -> array($minNumber, $maxNumber)
      */
 
@@ -25,9 +23,10 @@ class Dewey {
         $max = "";
 
         $decimalLocation = stripos($rangeString, ".");
+        
 
         // master number w/o decimal (we'll replace it later)
-        $master = preg_replace(array("/\./", "/\s/"), "", $rangeString);
+        $master = preg_replace("/\./", "", $rangeString);
         $length = strlen($master);
         $lastCharPlace = $length - 1;
         $xPos = array();
@@ -35,13 +34,13 @@ class Dewey {
         for ( $i = 0; $i < $length; $i++ ) {
             $char = $master[$i];
 
-            // any numeric, space, or period character gets added automatically
-            if ( preg_match("/[0-9]/", $char) ) {
+            // any numeric, space, or letter character gets added automatically
+            if ( preg_match("/[0-9a-z\s]/i", $char) ) {
                 $min .= $char;
                 $max .= $char;
             }
 
-            elseif ( preg_match("/x/i", $char) ) {
+            elseif ( preg_match("/\*/i", $char) ) {
                 // if we're at the first character, we need to stuff these values
                 if ( $i === 0 ) {
                     $min .= "0";
@@ -50,7 +49,7 @@ class Dewey {
                 } 
 
                 $prevChar = $master[$i - 1];
-                if ( $prevChar !== "x" && $prevChar !== "X" ) {
+                if ( $prevChar !== "*" ) {
                     $num = intval($prevChar);
                     $max[$i - 1] = ++$num;
                 }

--- a/test/CallNumberTest.php
+++ b/test/CallNumberTest.php
@@ -62,7 +62,7 @@ class CallNumberTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testInRange() {
-        $ranges = array("51x", "514.x", "514.1x", "514.12x", "514.123x");
+        $ranges = array("5**", "51*", "514.*", "514.1*", "514.12*", "514.123*", "514.123 A98*");
         foreach($ranges as $range) {
             $this->assertTrue(
                 $this->cn->inRange($range),
@@ -78,8 +78,8 @@ class CallNumberTest extends PHPUnit_Framework_TestCase {
 
     public function testInRangeLessThanMax() {
         $newCN = \Dewey::parseCallNumber("515");
-        $this->assertTrue($newCN->inRange("514.x"));
-        $this->assertFalse($newCN->inRange("514.x", false));
+        $this->assertTrue($newCN->inRange("514.*"));
+        $this->assertFalse($newCN->inRange("514.*", false));
     }
 
     public function testLessThan() {

--- a/test/DeweyTest.php
+++ b/test/DeweyTest.php
@@ -6,34 +6,42 @@ class DeweyTest extends PHPUnit_Framework_TestCase {
     public function testCalculateRange() {
         $this->assertEquals(
             array("740", "750"),
-            Dewey::calculateRange("74x"),
-            'Range works w/ ones-place X'
+            Dewey::calculateRange("74*"),
+            'Range works w/ ones-place *'
         );
 
         $this->assertEquals(
             array("700", "800"),
-            Dewey::calculateRange("7xx"),
-            'Range works w/ tens-place + ones-place Xs'
+            Dewey::calculateRange("7**"),
+            'Range works w/ tens-place + ones-place *s'
         );
     }
 
     public function testCalculateRangeDecimal() {
         $this->assertEquals(
             array("740.0", "741.0"),
-            Dewey::calculateRange("740.x"),
-            'Range affects ones-place when using single X'
+            Dewey::calculateRange("740.*"),
+            'Range affects ones-place when using single *'
         );
 
         $this->assertEquals(
             array("740.20", "740.30"),
-            Dewey::calculateRange("740.2x"),
+            Dewey::calculateRange("740.2*"),
             'Range drills down to tenths'
         );
 
         $this->assertEquals(
             array("740.22", "750.22"),
-            Dewey::calculateRange("74x.22"),
-            'If X is before decimal, leaves decimals in range'
+            Dewey::calculateRange("74*.22"),
+            'If * is before decimal, leaves decimals in range'
+        );
+    }
+
+    public function testCalculateRangeCutter() {
+        $this->assertEquals(
+            array("813 K5870", "813 K5880"),
+            Dewey::calculateRange("813 K587*"),
+            "Range should work with cutters" 
         );
     }
 
@@ -69,8 +77,8 @@ class DeweyTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testInRange() {
-        $this->assertTrue(Dewey::inRange($this->callNumber, "5xx"));
-        $this->assertTrue(Dewey::inRange($this->callNumber, "514.x"));
+        $this->assertTrue(Dewey::inRange($this->callNumber, "5**"));
+        $this->assertTrue(Dewey::inRange($this->callNumber, "514.*"));
         $this->assertFalse(Dewey::inRange($this->callNumber, $this->callNumber, false));
     }
 }


### PR DESCRIPTION
Not sure why `*` never occurred to me when thinking of what character to use for a delimiter, but that mistake should be fixed.
